### PR TITLE
Add templates for tracking app views

### DIFF
--- a/templates/tracking/measurements.html
+++ b/templates/tracking/measurements.html
@@ -1,0 +1,155 @@
+{% extends 'base.html' %}
+
+{% block title %}Medidas Corporales{% endblock %}
+
+{% block content %}
+<div class="space-y-8">
+    <div class="flex items-center justify-between flex-wrap gap-4">
+        <div>
+            <h1 class="text-3xl font-bold text-primary-dark">Medidas Corporales</h1>
+            <p class="text-gray-600">Controla tus medidas clave y analiza los cambios con tablas comparativas y gráficas.</p>
+        </div>
+        <a href="{% url 'tracking:weight_tracker' %}" class="inline-flex items-center px-4 py-2 bg-primary text-white rounded-lg shadow hover:bg-primary-dark transition">
+            <i class="fas fa-weight mr-2"></i> Ver Seguimiento de Peso
+        </a>
+    </div>
+
+    <div class="bg-white shadow rounded-xl p-6">
+        <h2 class="text-xl font-semibold text-primary-dark mb-4">Registrar / Actualizar Medidas</h2>
+        <form method="post" class="space-y-6">
+            {% csrf_token %}
+            <div class="grid md:grid-cols-3 gap-4">
+                {% for field in form.visible_fields %}
+                    {% if field.name != 'notes' %}
+                    <div>
+                        {{ field.label_tag }}
+                        {{ field }}
+                    </div>
+                    {% endif %}
+                {% endfor %}
+            </div>
+            <div>
+                {{ form.notes.label_tag }}
+                {{ form.notes }}
+            </div>
+            <div class="flex justify-end">
+                <button type="submit" class="inline-flex items-center px-5 py-2 bg-primary text-white rounded-lg shadow hover:bg-primary-dark transition">
+                    <i class="fas fa-save mr-2"></i> Guardar Medidas
+                </button>
+            </div>
+        </form>
+    </div>
+
+    <div class="bg-white shadow rounded-xl p-6">
+        <div class="flex items-center justify-between mb-4 flex-wrap gap-4">
+            <h2 class="text-xl font-semibold text-primary-dark">Tendencias de Medidas</h2>
+        </div>
+        <div class="relative h-96">
+            <canvas id="measurementsChart"></canvas>
+        </div>
+    </div>
+
+    <div class="bg-white shadow rounded-xl p-6">
+        <h2 class="text-xl font-semibold text-primary-dark mb-4">Historial y Cambios</h2>
+        <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200">
+                <thead class="bg-gray-50">
+                    <tr>
+                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Fecha</th>
+                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Pecho</th>
+                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Cintura</th>
+                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Cadera</th>
+                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Brazos</th>
+                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Muslos</th>
+                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Notas</th>
+                        <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Acciones</th>
+                    </tr>
+                </thead>
+                <tbody class="bg-white divide-y divide-gray-200">
+                    {% for record in measurements %}
+                    <tr class="hover:bg-gray-50">
+                        <td class="px-4 py-2 text-sm text-gray-700">{{ record.date }}</td>
+                        <td class="px-4 py-2 text-sm">
+                            {% include 'tracking/partials/measurement_cell.html' with value=record.chest %}
+                        </td>
+                        <td class="px-4 py-2 text-sm">
+                            {% include 'tracking/partials/measurement_cell.html' with value=record.waist %}
+                        </td>
+                        <td class="px-4 py-2 text-sm">
+                            {% include 'tracking/partials/measurement_cell.html' with value=record.hips %}
+                        </td>
+                        <td class="px-4 py-2 text-sm">
+                            {% include 'tracking/partials/measurement_cell.html' with value=record.arms %}
+                        </td>
+                        <td class="px-4 py-2 text-sm">
+                            {% include 'tracking/partials/measurement_cell.html' with value=record.thighs %}
+                        </td>
+                        <td class="px-4 py-2 text-sm text-gray-700">{{ record.notes|default:'—' }}</td>
+                        <td class="px-4 py-2 text-sm text-right">
+                            <form method="post" action="{% url 'tracking:measurement_delete' record.id %}" onsubmit="return confirm('¿Eliminar registro de medidas?');" class="inline">
+                                {% csrf_token %}
+                                <button type="submit" class="text-red-600 hover:text-red-800 font-semibold">
+                                    <i class="fas fa-trash-alt"></i>
+                                </button>
+                            </form>
+                        </td>
+                    </tr>
+                    {% empty %}
+                    <tr>
+                        <td colspan="8" class="px-4 py-6 text-center text-gray-500">Aún no hay registros de medidas.</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block extra_js %}
+{{ block.super }}
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+    const measurementsChartData = JSON.parse('{{ chart_data|escapejs }}');
+    const measurementColors = {
+        chest: '#1D4ED8',
+        waist: '#EF4444',
+        hips: '#10B981',
+        arms: '#F59E0B',
+        thighs: '#6366F1'
+    };
+
+    const measurementCtx = document.getElementById('measurementsChart').getContext('2d');
+    const datasets = Object.keys(measurementColors).map(key => ({
+        label: key.charAt(0).toUpperCase() + key.slice(1),
+        data: measurementsChartData[key],
+        borderColor: measurementColors[key],
+        backgroundColor: measurementColors[key] + '33',
+        spanGaps: true,
+        tension: 0.3
+    }));
+
+    new Chart(measurementCtx, {
+        type: 'line',
+        data: {
+            labels: measurementsChartData.dates,
+            datasets: datasets
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+                legend: {
+                    position: 'bottom'
+                }
+            },
+            scales: {
+                y: {
+                    beginAtZero: false,
+                    ticks: { callback: value => `${value} cm` }
+                }
+            }
+        }
+    });
+</script>
+{% endblock %}

--- a/templates/tracking/partials/measurement_cell.html
+++ b/templates/tracking/partials/measurement_cell.html
@@ -1,0 +1,10 @@
+{% if value.value %}
+<div class="font-semibold text-gray-900">{{ value.value }} cm</div>
+{% if value.change_symbol %}
+<span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-semibold {% if value.change_symbol == '↑' %}bg-red-100 text-red-600{% elif value.change_symbol == '↓' %}bg-green-100 text-green-600{% else %}bg-gray-100 text-gray-600{% endif %}">
+    {{ value.change_symbol }} {{ value.change|floatformat:1 }} cm
+</span>
+{% endif %}
+{% else %}
+<span class="text-gray-400">—</span>
+{% endif %}

--- a/templates/tracking/photo_compare.html
+++ b/templates/tracking/photo_compare.html
@@ -1,0 +1,114 @@
+{% extends 'base.html' %}
+
+{% block title %}Comparar Fotos{% endblock %}
+
+{% block content %}
+<div class="space-y-8">
+    <div class="flex items-center justify-between flex-wrap gap-4">
+        <div>
+            <h1 class="text-3xl font-bold text-primary-dark">Comparador de Fotos</h1>
+            <p class="text-gray-600">Selecciona un ángulo y dos fechas para evaluar visualmente tu progreso.</p>
+        </div>
+        <a href="{% url 'tracking:photos' %}" class="inline-flex items-center px-4 py-2 bg-primary text-white rounded-lg shadow hover:bg-primary-dark transition">
+            <i class="fas fa-calendar-alt mr-2"></i> Volver al Calendario
+        </a>
+    </div>
+
+    <div class="bg-white shadow rounded-xl p-6">
+        <h2 class="text-xl font-semibold text-primary-dark mb-4">Configurar comparación</h2>
+        <form method="get" class="grid md:grid-cols-4 gap-4 items-end">
+            <div>
+                <label for="photo_type" class="block text-sm font-medium text-gray-700">Tipo de foto</label>
+                <select id="photo_type" name="type" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent">
+                    {% for value, label in photos.model.PHOTO_TYPE_CHOICES %}
+                    <option value="{{ value }}" {% if value == photo_type %}selected{% endif %}>{{ label }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div>
+                <label for="date1" class="block text-sm font-medium text-gray-700">Fecha 1</label>
+                <select id="date1" name="date1" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent">
+                    <option value="">Selecciona...</option>
+                    {% for date in available_dates %}
+                    <option value="{{ date|date:'Y-m-d' }}" {% if date1 and date|date:'Y-m-d' == date1 %}selected{% endif %}>{{ date|date:'d \d\e F \d\e Y' }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div>
+                <label for="date2" class="block text-sm font-medium text-gray-700">Fecha 2</label>
+                <select id="date2" name="date2" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent">
+                    <option value="">Selecciona...</option>
+                    {% for date in available_dates %}
+                    <option value="{{ date|date:'Y-m-d' }}" {% if date2 and date|date:'Y-m-d' == date2 %}selected{% endif %}>{{ date|date:'d \d\e F \d\e Y' }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="flex gap-2">
+                <button type="submit" class="flex-1 inline-flex items-center justify-center px-4 py-2 bg-primary text-white rounded-lg shadow hover:bg-primary-dark transition">
+                    <i class="fas fa-sync-alt mr-2"></i> Comparar
+                </button>
+            </div>
+        </form>
+    </div>
+
+    <div class="grid lg:grid-cols-2 gap-6">
+        <div class="bg-white shadow rounded-xl overflow-hidden">
+            <div class="p-4 border-b">
+                <h2 class="text-lg font-semibold text-primary-dark flex items-center gap-2">
+                    <i class="fas fa-calendar-day"></i>
+                    {% if photo1 %}
+                        {{ photo1.date|date:'d \d\e F \d\e Y' }}
+                    {% else %}
+                        Fecha 1
+                    {% endif %}
+                </h2>
+            </div>
+            <div class="h-96 bg-gray-100 flex items-center justify-center">
+                {% if photo1 %}
+                    <img src="{{ photo1.photo.url }}" alt="Foto fecha 1" class="object-contain h-full w-full">
+                {% else %}
+                    <p class="text-gray-500">Selecciona una fecha disponible para ver la foto.</p>
+                {% endif %}
+            </div>
+        </div>
+        <div class="bg-white shadow rounded-xl overflow-hidden">
+            <div class="p-4 border-b">
+                <h2 class="text-lg font-semibold text-primary-dark flex items-center gap-2">
+                    <i class="fas fa-calendar-day"></i>
+                    {% if photo2 %}
+                        {{ photo2.date|date:'d \d\e F \d\e Y' }}
+                    {% else %}
+                        Fecha 2
+                    {% endif %}
+                </h2>
+            </div>
+            <div class="h-96 bg-gray-100 flex items-center justify-center">
+                {% if photo2 %}
+                    <img src="{{ photo2.photo.url }}" alt="Foto fecha 2" class="object-contain h-full w-full">
+                {% else %}
+                    <p class="text-gray-500">Selecciona una fecha disponible para ver la foto.</p>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+
+    <div class="bg-white shadow rounded-xl p-6">
+        <h2 class="text-xl font-semibold text-primary-dark mb-4">Galería del ángulo seleccionado</h2>
+        <div class="grid md:grid-cols-3 gap-4">
+            {% for photo in photos %}
+            <div class="border border-gray-200 rounded-xl overflow-hidden shadow-sm">
+                <div class="h-56 bg-gray-100">
+                    <img src="{{ photo.photo.url }}" alt="Foto {{ photo.date }}" class="w-full h-full object-cover">
+                </div>
+                <div class="p-4 space-y-1 text-sm text-gray-600">
+                    <div><i class="fas fa-calendar mr-1"></i>{{ photo.date|date:'d/m/Y' }}</div>
+                    <div><i class="fas fa-sticky-note mr-1"></i>{{ photo.notes|default:'Sin notas' }}</div>
+                </div>
+            </div>
+            {% empty %}
+            <p class="text-gray-500">Aún no hay fotos registradas para este ángulo.</p>
+            {% endfor %}
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/tracking/photos.html
+++ b/templates/tracking/photos.html
@@ -1,0 +1,215 @@
+{% extends 'base.html' %}
+
+{% block title %}Fotos de Progreso{% endblock %}
+
+{% block content %}
+<div class="space-y-8">
+    <div class="flex items-center justify-between flex-wrap gap-4">
+        <div>
+            <h1 class="text-3xl font-bold text-primary-dark">Diario Fotográfico</h1>
+            <p class="text-gray-600">Documenta tu progreso con imágenes organizadas por fecha y compara tus resultados.</p>
+        </div>
+        <a href="{% url 'tracking:photo_compare' %}" class="inline-flex items-center px-4 py-2 bg-primary text-white rounded-lg shadow hover:bg-primary-dark transition">
+            <i class="fas fa-columns mr-2"></i> Comparar Fotos
+        </a>
+    </div>
+
+    <div class="bg-white shadow rounded-xl p-6">
+        <h2 class="text-xl font-semibold text-primary-dark mb-4">Subir nueva foto</h2>
+        <form method="post" enctype="multipart/form-data" class="space-y-4">
+            {% csrf_token %}
+            <div class="grid md:grid-cols-2 gap-4">
+                <div>
+                    {{ form.photo.label_tag }}
+                    {{ form.photo }}
+                    {% if form.photo.help_text %}
+                    <p class="text-xs text-gray-500 mt-1">{{ form.photo.help_text }}</p>
+                    {% endif %}
+                </div>
+                <div>
+                    {{ form.photo_type.label_tag }}
+                    {{ form.photo_type }}
+                    {% if form.photo_type.help_text %}
+                    <p class="text-xs text-gray-500 mt-1">{{ form.photo_type.help_text }}</p>
+                    {% endif %}
+                </div>
+            </div>
+            <div>
+                {{ form.notes.label_tag }}
+                {{ form.notes }}
+            </div>
+            <div class="flex justify-end">
+                <button type="submit" class="inline-flex items-center px-5 py-2 bg-primary text-white rounded-lg shadow hover:bg-primary-dark transition">
+                    <i class="fas fa-upload mr-2"></i> Guardar Foto
+                </button>
+            </div>
+        </form>
+    </div>
+
+    <div class="bg-white shadow rounded-xl p-6">
+        <div class="flex items-center justify-between flex-wrap gap-4 mb-4">
+            <div>
+                <h2 class="text-xl font-semibold text-primary-dark">Calendario de Fotos</h2>
+                <p class="text-gray-500">Selecciona un día marcado para ver las fotos disponibles.</p>
+            </div>
+            <div class="flex items-center gap-2">
+                <a href="{% url 'tracking:photos' %}?year={{ prev_month.year }}&month={{ prev_month.month }}" class="px-3 py-2 rounded-lg bg-gray-200 hover:bg-gray-300 text-gray-700">
+                    <i class="fas fa-chevron-left"></i>
+                </a>
+                <span class="font-semibold text-primary-dark">{{ current_month|date:"F Y" }}</span>
+                <a href="{% url 'tracking:photos' %}?year={{ next_month.year }}&month={{ next_month.month }}" class="px-3 py-2 rounded-lg bg-gray-200 hover:bg-gray-300 text-gray-700">
+                    <i class="fas fa-chevron-right"></i>
+                </a>
+            </div>
+        </div>
+
+        <div class="grid grid-cols-7 gap-2 text-center text-sm font-semibold text-gray-500 mb-2">
+            <div>Lun</div>
+            <div>Mar</div>
+            <div>Mié</div>
+            <div>Jue</div>
+            <div>Vie</div>
+            <div>Sáb</div>
+            <div>Dom</div>
+        </div>
+        <div class="space-y-2">
+            {% for week in calendar %}
+            <div class="grid grid-cols-7 gap-2">
+                {% for day in week %}
+                    {% if day.day %}
+                    <button class="day-cell rounded-lg p-3 text-left border {% if day.has_photos %}border-primary text-primary-dark hover:bg-primary-light/60{% else %}border-gray-200 text-gray-400 cursor-default{% endif %}"
+                            data-date="{{ day.date }}"
+                            {% if not day.has_photos %}disabled{% endif %}>
+                        <span class="block text-lg font-semibold">{{ day.day }}</span>
+                        {% if day.has_photos %}
+                        <span class="text-xs">{{ day.photo_count }} foto{{ day.photo_count|pluralize:"s" }}</span>
+                        {% endif %}
+                    </button>
+                    {% else %}
+                    <div></div>
+                    {% endif %}
+                {% endfor %}
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+
+    <div class="bg-white shadow rounded-xl p-6">
+        <div class="flex items-center justify-between mb-4">
+            <h2 class="text-xl font-semibold text-primary-dark">Fotos del día seleccionado</h2>
+            <p id="selected-date" class="text-gray-500"></p>
+        </div>
+        <div id="photos-container" class="grid md:grid-cols-3 gap-4"></div>
+        <p id="no-photos-message" class="text-gray-500 text-center py-8 hidden">Selecciona un día con fotos en el calendario.</p>
+    </div>
+</div>
+{% endblock %}
+
+{% block extra_js %}
+{{ block.super }}
+<script>
+    const photosContainer = document.getElementById('photos-container');
+    const selectedDateLabel = document.getElementById('selected-date');
+    const noPhotosMessage = document.getElementById('no-photos-message');
+
+    function getCookie(name) {
+        const value = `; ${document.cookie}`;
+        const parts = value.split(`; ${name}=`);
+        if (parts.length === 2) return parts.pop().split(';').shift();
+    }
+
+    function clearPhotos() {
+        photosContainer.innerHTML = '';
+    }
+
+    function renderPhotos(photos) {
+        clearPhotos();
+        if (!photos.length) {
+            noPhotosMessage.classList.remove('hidden');
+            return;
+        }
+        noPhotosMessage.classList.add('hidden');
+        photos.forEach(photo => {
+            const card = document.createElement('div');
+            card.className = 'border border-gray-200 rounded-xl overflow-hidden shadow-sm';
+            card.innerHTML = `
+                <div class="relative h-56 bg-gray-100">
+                    <img src="${photo.url}" alt="Foto de progreso" class="w-full h-full object-cover">
+                    <button type="button" class="delete-photo px-3 py-1 rounded-full bg-red-500 text-white text-xs shadow absolute top-2 right-2" data-id="${photo.id}">
+                        <i class="fas fa-trash-alt"></i>
+                    </button>
+                </div>
+                <div class="p-4 space-y-2">
+                    <div class="flex justify-between text-sm text-gray-600">
+                        <span><i class="fas fa-camera mr-1"></i>${photo.type}</span>
+                        <span><i class="fas fa-calendar mr-1"></i>${photo.date}</span>
+                    </div>
+                    <p class="text-sm text-gray-700">${photo.notes || 'Sin notas adicionales.'}</p>
+                </div>
+            `;
+            photosContainer.appendChild(card);
+        });
+        attachDeleteHandlers();
+    }
+
+    function fetchPhotos(date) {
+        selectedDateLabel.textContent = new Date(date).toLocaleDateString('es-MX', { year: 'numeric', month: 'long', day: 'numeric' });
+        fetch(`{% url 'tracking:get_photos_for_date' %}?date=${date}`)
+            .then(response => response.json())
+            .then(data => {
+                if (data.photos) {
+                    const photosWithDeleteUrl = data.photos.map(photo => ({
+                        ...photo,
+                        delete_url: `{% url 'tracking:photo_delete' 0 %}`.replace('0', photo.id)
+                    }));
+                    renderPhotos(photosWithDeleteUrl);
+                } else {
+                    renderPhotos([]);
+                }
+            })
+            .catch(() => {
+                renderPhotos([]);
+            });
+    }
+
+    function attachDeleteHandlers() {
+        document.querySelectorAll('.delete-photo').forEach(button => {
+            button.addEventListener('click', () => {
+                const photoId = button.dataset.id;
+                if (!confirm('¿Eliminar esta foto?')) {
+                    return;
+                }
+                fetch(`{% url 'tracking:photo_delete' 0 %}`.replace('0', photoId), {
+                    method: 'POST',
+                    headers: {
+                        'X-CSRFToken': getCookie('csrftoken')
+                    }
+                })
+                .then(response => response.json())
+                .then(data => {
+                    if (data.status === 'success') {
+                        button.closest('.border').remove();
+                        if (!photosContainer.children.length) {
+                            noPhotosMessage.classList.remove('hidden');
+                        }
+                    }
+                });
+            });
+        });
+    }
+
+    document.querySelectorAll('.day-cell').forEach(button => {
+        button.addEventListener('click', () => {
+            const date = button.dataset.date;
+            if (!date) return;
+            document.querySelectorAll('.day-cell').forEach(btn => btn.classList.remove('ring-2', 'ring-primary'));
+            button.classList.add('ring-2', 'ring-primary');
+            fetchPhotos(date);
+        });
+    });
+
+    if (!photosContainer.children.length) {
+        noPhotosMessage.classList.remove('hidden');
+    }
+</script>
+{% endblock %}

--- a/templates/tracking/weight_tracker.html
+++ b/templates/tracking/weight_tracker.html
@@ -1,0 +1,217 @@
+{% extends 'base.html' %}
+{% load static %}
+
+{% block title %}Seguimiento de Peso{% endblock %}
+
+{% block content %}
+<div class="space-y-8">
+    <div class="flex items-center justify-between flex-wrap gap-4">
+        <div>
+            <h1 class="text-3xl font-bold text-primary-dark">Seguimiento de Peso</h1>
+            <p class="text-gray-600">Registra tu peso diario y visualiza tu progreso con estadísticas y gráficas.</p>
+        </div>
+        <a href="{% url 'tracking:measurements' %}" class="inline-flex items-center px-4 py-2 bg-primary text-white rounded-lg shadow hover:bg-primary-dark transition">
+            <i class="fas fa-ruler-combined mr-2"></i> Ver Medidas Corporales
+        </a>
+    </div>
+
+    <div class="bg-white shadow rounded-xl p-6">
+        <h2 class="text-xl font-semibold text-primary-dark mb-4">Registrar / Actualizar Peso</h2>
+        <form method="post" class="space-y-4">
+            {% csrf_token %}
+            <div class="grid md:grid-cols-2 gap-4">
+                <div>
+                    {{ form.weight.label_tag }}
+                    {{ form.weight }}
+                </div>
+                <div class="md:col-span-2">
+                    {{ form.notes.label_tag }}
+                    {{ form.notes }}
+                </div>
+            </div>
+            <div class="flex justify-end">
+                <button type="submit" class="inline-flex items-center px-5 py-2 bg-primary text-white rounded-lg shadow hover:bg-primary-dark transition">
+                    <i class="fas fa-save mr-2"></i> Guardar Peso
+                </button>
+            </div>
+        </form>
+    </div>
+
+    {% if stats %}
+    <div>
+        <h2 class="text-xl font-semibold text-primary-dark mb-4">Resumen de Progreso</h2>
+        <div class="grid sm:grid-cols-2 lg:grid-cols-4 gap-4">
+            <div class="bg-white shadow rounded-xl p-5 border-l-4 border-primary">
+                <p class="text-sm text-gray-500">Peso Inicial</p>
+                <p class="text-2xl font-semibold text-primary-dark">{{ stats.inicio.peso }} kg</p>
+                <p class="text-xs text-gray-400">{{ stats.inicio.fecha }}</p>
+            </div>
+            <div class="bg-white shadow rounded-xl p-5 border-l-4 border-primary-dark">
+                <p class="text-sm text-gray-500">Peso Actual</p>
+                <p class="text-2xl font-semibold text-primary-dark">{{ stats.actual.peso }} kg</p>
+                <p class="text-xs text-gray-400">{{ stats.actual.fecha }}</p>
+            </div>
+            <div class="bg-white shadow rounded-xl p-5 border-l-4 border-green-500">
+                <p class="text-sm text-gray-500">Cambio Total</p>
+                <p class="text-2xl font-semibold {% if stats.cambio_total <= 0 %}text-green-600{% else %}text-red-600{% endif %}">
+                    {{ stats.cambio_total|floatformat:1 }} kg
+                </p>
+                <p class="text-xs text-gray-400">Desde el inicio</p>
+            </div>
+            <div class="bg-white shadow rounded-xl p-5 border-l-4 border-warning">
+                <p class="text-sm text-gray-500">Promedio Último Mes</p>
+                <p class="text-2xl font-semibold text-primary-dark">{{ stats.promedio_mes|default:stats.actual.peso|floatformat:1 }} kg</p>
+                <p class="text-xs text-gray-400">Cambio mes: {{ stats.cambio_mes|floatformat:1 }} kg</p>
+            </div>
+        </div>
+    </div>
+    {% endif %}
+
+    <div class="bg-white shadow rounded-xl p-6">
+        <div class="flex items-center justify-between mb-4 flex-wrap gap-4">
+            <h2 class="text-xl font-semibold text-primary-dark">Evolución del Peso</h2>
+            <div class="flex gap-2">
+                <button data-target="daily" class="chart-tab active px-3 py-1 rounded-lg bg-primary text-white text-sm">Diario</button>
+                <button data-target="weekly" class="chart-tab px-3 py-1 rounded-lg bg-gray-200 text-gray-700 text-sm hover:bg-gray-300">Semanal</button>
+                <button data-target="monthly" class="chart-tab px-3 py-1 rounded-lg bg-gray-200 text-gray-700 text-sm hover:bg-gray-300">Mensual</button>
+            </div>
+        </div>
+        <div class="relative h-80">
+            <canvas id="weightChart"></canvas>
+        </div>
+    </div>
+
+    <div class="bg-white shadow rounded-xl p-6">
+        <div class="flex items-center justify-between mb-4 flex-wrap gap-4">
+            <h2 class="text-xl font-semibold text-primary-dark">Historial de Registros</h2>
+        </div>
+        <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200">
+                <thead class="bg-gray-50">
+                    <tr>
+                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Fecha</th>
+                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Peso</th>
+                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Cambio</th>
+                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Notas</th>
+                        <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Acciones</th>
+                    </tr>
+                </thead>
+                <tbody class="bg-white divide-y divide-gray-200">
+                    {% for record in weight_records %}
+                    <tr class="hover:bg-gray-50">
+                        <td class="px-4 py-2 text-sm text-gray-700">{{ record.date }}</td>
+                        <td class="px-4 py-2 text-sm text-gray-900 font-semibold">{{ record.weight }} kg</td>
+                        <td class="px-4 py-2 text-sm">
+                            {% if record.change_symbol %}
+                                <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-semibold {% if record.change_symbol == '↑' %}bg-red-100 text-red-600{% elif record.change_symbol == '↓' %}bg-green-100 text-green-600{% else %}bg-gray-100 text-gray-600{% endif %}">
+                                    {{ record.change_symbol }} {{ record.change|floatformat:1 }} kg
+                                </span>
+                            {% else %}
+                                <span class="text-gray-400">—</span>
+                            {% endif %}
+                        </td>
+                        <td class="px-4 py-2 text-sm text-gray-700">{{ record.notes|default:'—' }}</td>
+                        <td class="px-4 py-2 text-sm text-right">
+                            <form method="post" action="{% url 'tracking:weight_delete' record.id %}" onsubmit="return confirm('¿Eliminar registro de peso?');" class="inline">
+                                {% csrf_token %}
+                                <button type="submit" class="text-red-600 hover:text-red-800 font-semibold">
+                                    <i class="fas fa-trash-alt"></i>
+                                </button>
+                            </form>
+                        </td>
+                    </tr>
+                    {% empty %}
+                    <tr>
+                        <td colspan="5" class="px-4 py-6 text-center text-gray-500">Aún no hay registros de peso.</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block extra_js %}
+{{ block.super }}
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+    const chartData = JSON.parse('{{ chart_data|escapejs }}');
+    const ctx = document.getElementById('weightChart').getContext('2d');
+    const colors = {
+        primary: '#219EBC',
+        primaryLight: '#8ECAE6',
+        primaryDark: '#023047'
+    };
+
+    function buildDataset(type) {
+        if (type === 'daily') {
+            return {
+                labels: chartData.daily.map(item => item.date),
+                datasets: [{
+                    label: 'Peso (kg)',
+                    data: chartData.daily.map(item => item.weight),
+                    borderColor: colors.primary,
+                    backgroundColor: colors.primaryLight,
+                    tension: 0.3,
+                    fill: true
+                }]
+            };
+        }
+        if (type === 'weekly') {
+            return {
+                labels: Object.keys(chartData.weekly),
+                datasets: [{
+                    label: 'Peso promedio semanal (kg)',
+                    data: Object.values(chartData.weekly),
+                    borderColor: colors.primaryDark,
+                    backgroundColor: colors.primary,
+                    tension: 0.3,
+                    fill: true
+                }]
+            };
+        }
+        return {
+            labels: Object.keys(chartData.monthly),
+            datasets: [{
+                label: 'Peso promedio mensual (kg)',
+                data: Object.values(chartData.monthly),
+                borderColor: colors.primary,
+                backgroundColor: colors.primaryDark,
+                tension: 0.3,
+                fill: true
+            }]
+        };
+    }
+
+    let currentType = 'daily';
+    const weightChart = new Chart(ctx, {
+        type: 'line',
+        data: buildDataset(currentType),
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            scales: {
+                y: {
+                    beginAtZero: false,
+                    ticks: { callback: value => `${value} kg` }
+                }
+            }
+        }
+    });
+
+    document.querySelectorAll('.chart-tab').forEach(button => {
+        button.addEventListener('click', () => {
+            document.querySelectorAll('.chart-tab').forEach(btn => {
+                btn.classList.remove('bg-primary', 'text-white', 'active');
+                btn.classList.add('bg-gray-200', 'text-gray-700');
+            });
+            button.classList.add('bg-primary', 'text-white', 'active');
+            button.classList.remove('bg-gray-200', 'text-gray-700');
+            currentType = button.dataset.target;
+            weightChart.data = buildDataset(currentType);
+            weightChart.update();
+        });
+    });
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a dedicated weight tracker template with statistics, charts, and history table
- provide measurement tracking templates including reusable measurement cell partial and multi-metric chart
- create progress photo calendar, gallery, and comparison templates for the tracking module

## Testing
- python manage.py check *(fails: Django not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b15a358c833080b87825ff5681cf