### PR TITLE
Adjust weight tracker layout and history table

### DIFF
--- a/templates/tracking/weight_tracker.html
+++ b/templates/tracking/weight_tracker.html
@@ -15,26 +15,79 @@
         </a>
     </div>
 
-    <div class="bg-white shadow rounded-xl p-6">
-        <h2 class="text-xl font-semibold text-primary-dark mb-4">Registrar / Actualizar Peso</h2>
-        <form method="post" class="space-y-4">
-            {% csrf_token %}
-            <div class="grid md:grid-cols-2 gap-4">
-                <div>
-                    {{ form.weight.label_tag }}
-                    {{ form.weight }}
+    <div class="grid xl:grid-cols-2 gap-6 items-start">
+        <div class="bg-white shadow rounded-xl p-6">
+            <h2 class="text-xl font-semibold text-primary-dark mb-4">Registrar / Actualizar Peso</h2>
+            <form method="post" class="space-y-4">
+                {% csrf_token %}
+                <div class="grid md:grid-cols-2 gap-4">
+                    <div>
+                        {{ form.weight.label_tag }}
+                        {{ form.weight }}
+                    </div>
+                    <div class="md:col-span-2">
+                        {{ form.notes.label_tag }}
+                        {{ form.notes }}
+                    </div>
                 </div>
-                <div class="md:col-span-2">
-                    {{ form.notes.label_tag }}
-                    {{ form.notes }}
+                <div class="flex justify-end">
+                    <button type="submit" class="inline-flex items-center px-5 py-2 bg-primary text-white rounded-lg shadow hover:bg-primary-dark transition">
+                        <i class="fas fa-save mr-2"></i> Guardar Peso
+                    </button>
+                </div>
+            </form>
+        </div>
+
+        <div class="bg-white shadow rounded-xl p-6">
+            <div class="flex items-center justify-between mb-4 flex-wrap gap-4">
+                <h2 class="text-xl font-semibold text-primary-dark">Historial de Registros</h2>
+            </div>
+            <div class="overflow-x-auto">
+                <div class="max-h-96 overflow-y-auto">
+                    <table class="min-w-full divide-y divide-gray-200">
+                        <thead class="bg-gray-50">
+                            <tr>
+                                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Fecha</th>
+                                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Peso</th>
+                                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Cambio</th>
+                                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Notas</th>
+                                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Acciones</th>
+                            </tr>
+                        </thead>
+                        <tbody class="bg-white divide-y divide-gray-200">
+                            {% for record in weight_records %}
+                            <tr class="hover:bg-gray-50">
+                                <td class="px-4 py-2 text-sm text-gray-700">{{ record.date }}</td>
+                                <td class="px-4 py-2 text-sm text-gray-900 font-semibold">{{ record.weight }} kg</td>
+                                <td class="px-4 py-2 text-sm">
+                                    {% if record.change_symbol %}
+                                        <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-semibold {% if record.change_symbol == '↑' %}bg-red-100 text-red-600{% elif record.change_symbol == '↓' %}bg-green-100 text-green-600{% else %}bg-gray-100 text-gray-600{% endif %}">
+                                            {{ record.change_symbol }} {{ record.change|floatformat:1 }} kg
+                                        </span>
+                                    {% else %}
+                                        <span class="text-gray-400">—</span>
+                                    {% endif %}
+                                </td>
+                                <td class="px-4 py-2 text-sm text-gray-700">{{ record.notes|default:'—' }}</td>
+                                <td class="px-4 py-2 text-sm text-right">
+                                    <form method="post" action="{% url 'tracking:weight_delete' record.id %}" onsubmit="return confirm('¿Eliminar registro de peso?');" class="inline">
+                                        {% csrf_token %}
+                                        <button type="submit" class="text-red-600 hover:text-red-800 font-semibold">
+                                            <i class="fas fa-trash-alt"></i>
+                                        </button>
+                                    </form>
+                                </td>
+                            </tr>
+                            {% empty %}
+                            <tr>
+                                <td colspan="5" class="px-4 py-6 text-center text-gray-500">Aún no hay registros de peso.</td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
                 </div>
             </div>
-            <div class="flex justify-end">
-                <button type="submit" class="inline-flex items-center px-5 py-2 bg-primary text-white rounded-lg shadow hover:bg-primary-dark transition">
-                    <i class="fas fa-save mr-2"></i> Guardar Peso
-                </button>
-            </div>
-        </form>
+        </div>
     </div>
 
     {% if stats %}
@@ -81,54 +134,6 @@
         </div>
     </div>
 
-    <div class="bg-white shadow rounded-xl p-6">
-        <div class="flex items-center justify-between mb-4 flex-wrap gap-4">
-            <h2 class="text-xl font-semibold text-primary-dark">Historial de Registros</h2>
-        </div>
-        <div class="overflow-x-auto">
-            <table class="min-w-full divide-y divide-gray-200">
-                <thead class="bg-gray-50">
-                    <tr>
-                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Fecha</th>
-                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Peso</th>
-                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Cambio</th>
-                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Notas</th>
-                        <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Acciones</th>
-                    </tr>
-                </thead>
-                <tbody class="bg-white divide-y divide-gray-200">
-                    {% for record in weight_records %}
-                    <tr class="hover:bg-gray-50">
-                        <td class="px-4 py-2 text-sm text-gray-700">{{ record.date }}</td>
-                        <td class="px-4 py-2 text-sm text-gray-900 font-semibold">{{ record.weight }} kg</td>
-                        <td class="px-4 py-2 text-sm">
-                            {% if record.change_symbol %}
-                                <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-semibold {% if record.change_symbol == '↑' %}bg-red-100 text-red-600{% elif record.change_symbol == '↓' %}bg-green-100 text-green-600{% else %}bg-gray-100 text-gray-600{% endif %}">
-                                    {{ record.change_symbol }} {{ record.change|floatformat:1 }} kg
-                                </span>
-                            {% else %}
-                                <span class="text-gray-400">—</span>
-                            {% endif %}
-                        </td>
-                        <td class="px-4 py-2 text-sm text-gray-700">{{ record.notes|default:'—' }}</td>
-                        <td class="px-4 py-2 text-sm text-right">
-                            <form method="post" action="{% url 'tracking:weight_delete' record.id %}" onsubmit="return confirm('¿Eliminar registro de peso?');" class="inline">
-                                {% csrf_token %}
-                                <button type="submit" class="text-red-600 hover:text-red-800 font-semibold">
-                                    <i class="fas fa-trash-alt"></i>
-                                </button>
-                            </form>
-                        </td>
-                    </tr>
-                    {% empty %}
-                    <tr>
-                        <td colspan="5" class="px-4 py-6 text-center text-gray-500">Aún no hay registros de peso.</td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </div>
-    </div>
 </div>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- group the weight entry form and history cards in a responsive two-column grid
- wrap the history table in scrollable containers to preserve its minimum width and allow vertical scrolling
- remove the duplicate history section after repositioning the card

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6b6ddf71483309d7c900c839d4c4b