### PR TITLE
Add quick access to photo diary from weight tracker

### DIFF
--- a/templates/tracking/measurements.html
+++ b/templates/tracking/measurements.html
@@ -14,30 +14,89 @@
         </a>
     </div>
 
-    <div class="bg-white shadow rounded-xl p-6">
-        <h2 class="text-xl font-semibold text-primary-dark mb-4">Registrar / Actualizar Medidas</h2>
-        <form method="post" class="space-y-6">
-            {% csrf_token %}
-            <div class="grid md:grid-cols-3 gap-4">
-                {% for field in form.visible_fields %}
-                    {% if field.name != 'notes' %}
-                    <div>
-                        {{ field.label_tag }}
-                        {{ field }}
-                    </div>
-                    {% endif %}
-                {% endfor %}
+    <div class="grid xl:grid-cols-2 gap-6 items-start">
+        <div class="bg-white shadow rounded-xl p-6">
+            <h2 class="text-xl font-semibold text-primary-dark mb-4">Registrar / Actualizar Medidas</h2>
+            <form method="post" class="space-y-6">
+                {% csrf_token %}
+                <div class="grid md:grid-cols-3 gap-4">
+                    {% for field in form.visible_fields %}
+                        {% if field.name != 'notes' %}
+                        <div>
+                            {{ field.label_tag }}
+                            {{ field }}
+                        </div>
+                        {% endif %}
+                    {% endfor %}
+                </div>
+                <div>
+                    {{ form.notes.label_tag }}
+                    {{ form.notes }}
+                </div>
+                <div class="flex justify-end">
+                    <button type="submit" class="inline-flex items-center px-5 py-2 bg-primary text-white rounded-lg shadow hover:bg-primary-dark transition">
+                        <i class="fas fa-save mr-2"></i> Guardar Medidas
+                    </button>
+                </div>
+            </form>
+        </div>
+
+        <div class="bg-white shadow rounded-xl p-6">
+            <h2 class="text-xl font-semibold text-primary-dark mb-4">Historial y Cambios</h2>
+            <div class="overflow-x-auto">
+                <div class="max-h-96 overflow-y-auto">
+                    <table class="min-w-full divide-y divide-gray-200">
+                        <thead class="bg-gray-50">
+                            <tr>
+                                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Fecha</th>
+                                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Pecho</th>
+                                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Cintura</th>
+                                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Cadera</th>
+                                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Brazos</th>
+                                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Muslos</th>
+                                <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Notas</th>
+                                <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Acciones</th>
+                            </tr>
+                        </thead>
+                        <tbody class="bg-white divide-y divide-gray-200">
+                            {% for record in measurements %}
+                            <tr class="hover:bg-gray-50">
+                                <td class="px-4 py-2 text-sm text-gray-700">{{ record.date }}</td>
+                                <td class="px-4 py-2 text-sm">
+                                    {% include 'tracking/partials/measurement_cell.html' with value=record.chest %}
+                                </td>
+                                <td class="px-4 py-2 text-sm">
+                                    {% include 'tracking/partials/measurement_cell.html' with value=record.waist %}
+                                </td>
+                                <td class="px-4 py-2 text-sm">
+                                    {% include 'tracking/partials/measurement_cell.html' with value=record.hips %}
+                                </td>
+                                <td class="px-4 py-2 text-sm">
+                                    {% include 'tracking/partials/measurement_cell.html' with value=record.arms %}
+                                </td>
+                                <td class="px-4 py-2 text-sm">
+                                    {% include 'tracking/partials/measurement_cell.html' with value=record.thighs %}
+                                </td>
+                                <td class="px-4 py-2 text-sm text-gray-700">{{ record.notes|default:'—' }}</td>
+                                <td class="px-4 py-2 text-sm text-right">
+                                    <form method="post" action="{% url 'tracking:measurement_delete' record.id %}" onsubmit="return confirm('¿Eliminar registro de medidas?');" class="inline">
+                                        {% csrf_token %}
+                                        <button type="submit" class="text-red-600 hover:text-red-800 font-semibold">
+                                            <i class="fas fa-trash-alt"></i>
+                                        </button>
+                                    </form>
+                                </td>
+                            </tr>
+                            {% empty %}
+                            <tr>
+                                <td colspan="8" class="px-4 py-6 text-center text-gray-500">Aún no hay registros de medidas.</td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
             </div>
-            <div>
-                {{ form.notes.label_tag }}
-                {{ form.notes }}
-            </div>
-            <div class="flex justify-end">
-                <button type="submit" class="inline-flex items-center px-5 py-2 bg-primary text-white rounded-lg shadow hover:bg-primary-dark transition">
-                    <i class="fas fa-save mr-2"></i> Guardar Medidas
-                </button>
-            </div>
-        </form>
+        </div>
     </div>
 
     <div class="bg-white shadow rounded-xl p-6">
@@ -46,61 +105,6 @@
         </div>
         <div class="relative h-96">
             <canvas id="measurementsChart"></canvas>
-        </div>
-    </div>
-
-    <div class="bg-white shadow rounded-xl p-6">
-        <h2 class="text-xl font-semibold text-primary-dark mb-4">Historial y Cambios</h2>
-        <div class="overflow-x-auto">
-            <table class="min-w-full divide-y divide-gray-200">
-                <thead class="bg-gray-50">
-                    <tr>
-                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Fecha</th>
-                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Pecho</th>
-                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Cintura</th>
-                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Cadera</th>
-                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Brazos</th>
-                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Muslos</th>
-                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Notas</th>
-                        <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Acciones</th>
-                    </tr>
-                </thead>
-                <tbody class="bg-white divide-y divide-gray-200">
-                    {% for record in measurements %}
-                    <tr class="hover:bg-gray-50">
-                        <td class="px-4 py-2 text-sm text-gray-700">{{ record.date }}</td>
-                        <td class="px-4 py-2 text-sm">
-                            {% include 'tracking/partials/measurement_cell.html' with value=record.chest %}
-                        </td>
-                        <td class="px-4 py-2 text-sm">
-                            {% include 'tracking/partials/measurement_cell.html' with value=record.waist %}
-                        </td>
-                        <td class="px-4 py-2 text-sm">
-                            {% include 'tracking/partials/measurement_cell.html' with value=record.hips %}
-                        </td>
-                        <td class="px-4 py-2 text-sm">
-                            {% include 'tracking/partials/measurement_cell.html' with value=record.arms %}
-                        </td>
-                        <td class="px-4 py-2 text-sm">
-                            {% include 'tracking/partials/measurement_cell.html' with value=record.thighs %}
-                        </td>
-                        <td class="px-4 py-2 text-sm text-gray-700">{{ record.notes|default:'—' }}</td>
-                        <td class="px-4 py-2 text-sm text-right">
-                            <form method="post" action="{% url 'tracking:measurement_delete' record.id %}" onsubmit="return confirm('¿Eliminar registro de medidas?');" class="inline">
-                                {% csrf_token %}
-                                <button type="submit" class="text-red-600 hover:text-red-800 font-semibold">
-                                    <i class="fas fa-trash-alt"></i>
-                                </button>
-                            </form>
-                        </td>
-                    </tr>
-                    {% empty %}
-                    <tr>
-                        <td colspan="8" class="px-4 py-6 text-center text-gray-500">Aún no hay registros de medidas.</td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
         </div>
     </div>
 </div>

--- a/templates/tracking/weight_tracker.html
+++ b/templates/tracking/weight_tracker.html
@@ -10,9 +10,14 @@
             <h1 class="text-3xl font-bold text-primary-dark">Seguimiento de Peso</h1>
             <p class="text-gray-600">Registra tu peso diario y visualiza tu progreso con estadísticas y gráficas.</p>
         </div>
-        <a href="{% url 'tracking:measurements' %}" class="inline-flex items-center px-4 py-2 bg-primary text-white rounded-lg shadow hover:bg-primary-dark transition">
-            <i class="fas fa-ruler-combined mr-2"></i> Ver Medidas Corporales
-        </a>
+        <div class="flex flex-wrap gap-2">
+            <a href="{% url 'tracking:measurements' %}" class="inline-flex items-center px-4 py-2 bg-primary text-white rounded-lg shadow hover:bg-primary-dark transition">
+                <i class="fas fa-ruler-combined mr-2"></i> Ver Medidas Corporales
+            </a>
+            <a href="{% url 'tracking:photos' %}" class="inline-flex items-center px-4 py-2 bg-primary-dark text-white rounded-lg shadow hover:bg-primary transition">
+                <i class="fas fa-camera mr-2"></i> Diario Fotográfico
+            </a>
+        </div>
     </div>
 
     <div class="bg-white shadow rounded-xl p-6">


### PR DESCRIPTION
## Summary
- add a quick-access button in the weight tracker header that links to the photo diary view

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6b6cf66e083308901bec2367f231f