### PR TITLE
Update format_money filter formatting

### DIFF
--- a/finances/templatetags/expense_filters.py
+++ b/finances/templatetags/expense_filters.py
@@ -1,11 +1,13 @@
 from django import template
+from django.utils.formats import number_format
 
 register = template.Library()
 
 @register.filter
 def format_money(value):
     try:
-        return "{:,.0f}".format(float(value))
+        formatted = number_format(value, decimal_pos=0, use_l10n=True)
+        return formatted.replace(",", ".")
     except (ValueError, TypeError):
         return "0"
 

--- a/finances/tests.py
+++ b/finances/tests.py
@@ -1,3 +1,12 @@
-from django.test import TestCase
+from django.test import SimpleTestCase
 
-# Create your tests here.
+from finances.templatetags.expense_filters import format_money
+
+
+class FormatMoneyFilterTests(SimpleTestCase):
+    def test_format_money_formats_thousands_with_dots(self):
+        self.assertEqual(format_money(50000), "50.000")
+
+    def test_format_money_invalid_values_return_zero(self):
+        self.assertEqual(format_money("invalid"), "0")
+        self.assertEqual(format_money(None), "0")


### PR DESCRIPTION
## Summary
- update the `format_money` template filter to rely on Django's `number_format`, guaranteeing thousands separators with dots and no decimals
- add unit tests that assert formatting for valid values and graceful handling of invalid inputs

## Testing
- `python manage.py test finances` *(fails: Django is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6ca7e41f08330aa20ac4eac7bf17c