### PR TITLE
Ensure format_money forces thousands separator

### DIFF
--- a/finances/templatetags/expense_filters.py
+++ b/finances/templatetags/expense_filters.py
@@ -1,11 +1,18 @@
 from django import template
+from django.utils.formats import number_format
 
 register = template.Library()
 
 @register.filter
 def format_money(value):
     try:
-        return "{:,.0f}".format(float(value))
+        formatted = number_format(
+            value,
+            decimal_pos=0,
+            use_l10n=True,
+            force_grouping=True,
+        )
+        return formatted.replace(",", ".")
     except (ValueError, TypeError):
         return "0"
 

--- a/finances/tests.py
+++ b/finances/tests.py
@@ -1,3 +1,12 @@
-from django.test import TestCase
+from django.test import SimpleTestCase
 
-# Create your tests here.
+from finances.templatetags.expense_filters import format_money
+
+
+class FormatMoneyFilterTests(SimpleTestCase):
+    def test_format_money_formats_thousands_with_dots(self):
+        self.assertEqual(format_money(50000), "50.000")
+
+    def test_format_money_invalid_values_return_zero(self):
+        self.assertEqual(format_money("invalid"), "0")
+        self.assertEqual(format_money(None), "0")


### PR DESCRIPTION
## Summary
- force the `format_money` template filter to always apply thousands grouping

## Testing
- `python manage.py test finances` *(fails: Django is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6ca7e41f08330aa20ac4eac7bf17c