### PR TITLE
Format dashboard remnant card values without decimals

### DIFF
--- a/dashboard/tests.py
+++ b/dashboard/tests.py
@@ -7,6 +7,8 @@ from django.utils import timezone
 
 from finances.models import AnnualFlow, MonthlyIncomeBook, Remnant
 
+from .views import format_currency
+
 
 class DashboardViewTests(TestCase):
     def setUp(self):
@@ -41,6 +43,5 @@ class DashboardViewTests(TestCase):
             {'label': 'Flujos Anual', 'value': str(flow_year)}
         )
         remnant_value = finance_app['stats'][1]['value']
-        self.assertTrue(remnant_value.startswith('$'))
-        self.assertIn('150.50', remnant_value)
+        self.assertEqual(remnant_value, format_currency(Decimal('150.50')))
         self.assertEqual(finance_app['stats'][1]['label'], 'Remanentes')

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -1,10 +1,24 @@
-from django.shortcuts import render
-from django.contrib.auth.decorators import login_required
 from datetime import datetime, timedelta
+from decimal import Decimal, InvalidOperation, ROUND_DOWN
 
+from django.contrib.auth.decorators import login_required
+from django.shortcuts import render
+from django.utils.formats import number_format
 
 def format_currency(amount):
-    return f"${amount:,.2f}" if amount is not None else "$0.00"
+    try:
+        if amount in (None, ""):
+            return "$0"
+        normalized = Decimal(str(amount)).quantize(Decimal("1"), rounding=ROUND_DOWN)
+        formatted = number_format(
+            normalized,
+            decimal_pos=0,
+            use_l10n=True,
+            force_grouping=True,
+        )
+        return f"${formatted.replace(',', '.')}"
+    except (TypeError, ValueError, InvalidOperation):
+        return "$0"
 
 
 @login_required
@@ -46,7 +60,7 @@ def dashboard_view(request):
         recent_photos = 0
         finance_stats = [
             {'label': 'Flujos Anual', 'value': str(datetime.now().year)},
-            {'label': 'Remanentes', 'value': "$0.00"},
+            {'label': 'Remanentes', 'value': format_currency(0)},
         ]
 
     apps = [

--- a/finances/templatetags/expense_filters.py
+++ b/finances/templatetags/expense_filters.py
@@ -1,11 +1,18 @@
 from django import template
+from django.utils.formats import number_format
 
 register = template.Library()
 
 @register.filter
 def format_money(value):
     try:
-        return "{:,.0f}".format(float(value))
+        formatted = number_format(
+            value,
+            decimal_pos=0,
+            use_l10n=True,
+            force_grouping=True,
+        )
+        return formatted.replace(",", ".")
     except (ValueError, TypeError):
         return "0"
 

--- a/finances/tests.py
+++ b/finances/tests.py
@@ -1,3 +1,12 @@
-from django.test import TestCase
+from django.test import SimpleTestCase
 
-# Create your tests here.
+from finances.templatetags.expense_filters import format_money
+
+
+class FormatMoneyFilterTests(SimpleTestCase):
+    def test_format_money_formats_thousands_with_dots(self):
+        self.assertEqual(format_money(50000), "50.000")
+
+    def test_format_money_invalid_values_return_zero(self):
+        self.assertEqual(format_money("invalid"), "0")
+        self.assertEqual(format_money(None), "0")


### PR DESCRIPTION
## Summary
- format the dashboard remnant stat using thousands separators without decimals
- normalize the currency helper to drop fractional amounts safely and reuse it in fallbacks
- update the dashboard view test to assert the new formatting helper output

## Testing
- `python manage.py test dashboard` *(fails: Django is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6ca7e41f08330aa20ac4eac7bf17c