### PR TITLE
Add dashboard card for Linux command app

### DIFF
--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -34,6 +34,7 @@ def dashboard_view(request):
     try:
         from tracking.models import WeightRecord, BodyMeasurement, ProgressPhoto
         from finances.models import AnnualFlow
+        from linux_commands.models import CommandTag, LinuxCommand
         from tasks.models import Task
 
         # Obtener estadísticas de tracking
@@ -74,6 +75,9 @@ def dashboard_view(request):
             last_completed=today,
         ).count()
 
+        linux_commands_count = LinuxCommand.objects.filter(owner=request.user).count()
+        linux_tags_count = CommandTag.objects.filter(commands__owner=request.user).distinct().count()
+
 
     except Exception:
         weight_stats = {'current': None, 'date': None}
@@ -86,6 +90,8 @@ def dashboard_view(request):
         tasks_today_count = 0
 
         tasks_completed_today_count = 0
+        linux_commands_count = 0
+        linux_tags_count = 0
 
 
     apps = [
@@ -118,6 +124,17 @@ def dashboard_view(request):
                 {'label': 'Pendientes hoy', 'value': str(tasks_today_count)},
                 {'label': 'Completadas hoy', 'value': str(tasks_completed_today_count)},
 
+            ]
+        },
+        {
+            'name': 'Aprendizaje de comandos de Linux',
+            'description': 'Guarda comandos, banderas y etiquetas personalizadas',
+            'icon': 'fas fa-terminal',
+            'url': 'linux_commands:list',
+            'color': 'bg-secondary',
+            'stats': [
+                {'label': 'Comandos guardados', 'value': str(linux_commands_count)},
+                {'label': 'Etiquetas únicas', 'value': str(linux_tags_count)},
             ]
         },
     ]

--- a/templates/base.html
+++ b/templates/base.html
@@ -20,6 +20,7 @@
                         'primary-dark': '#023047',
                         'primary': '#219EBC',
                         'primary-light': '#8ECAE6',
+                        'secondary': '#8B5CF6',
                         'info': '#0284C7',
                         'warning': '#FFB703',
                         'danger': '#FB8500',
@@ -76,9 +77,6 @@
                 <div class="flex items-center space-x-6">
                     <a href="{% url 'dashboard' %}" class="text-white hover:text-primary-light transition">
                         <i class="fas fa-home"></i> Dashboard
-                    </a>
-                    <a href="{% url 'linux_commands:list' %}" class="text-white hover:text-primary-light transition">
-                        <i class="fas fa-terminal"></i> Comandos Linux
                     </a>
                     <a href="{% url 'admin:index' %}" class="text-white hover:text-primary-light transition">
                         <i class="fas fa-cog"></i> Admin Panel


### PR DESCRIPTION
## Summary
- add Linux command statistics to the dashboard apps grid and link to the module there
- remove the Linux commands entry from the global navigation and extend the Tailwind palette with a secondary color

## Testing
- python manage.py test linux_commands dashboard

------
https://chatgpt.com/codex/tasks/task_e_68dc7d3de5988330bb9c98bee97dc1c7