### PR TITLE
Adjust Linux commands list layout

### DIFF
--- a/linux_commands/templates/linux_commands/command_list.html
+++ b/linux_commands/templates/linux_commands/command_list.html
@@ -51,60 +51,70 @@
     </div>
 
     {% if commands %}
-    <div class="grid gap-6 md:grid-cols-2">
+    <div class="grid grid-cols-1 gap-6">
         {% for command in commands %}
-        <div class="bg-white rounded-lg shadow p-6 flex flex-col gap-4">
-            <div class="flex items-start justify-between gap-3">
-                <div class="flex-1">
+        <div class="bg-white rounded-lg shadow p-6">
+            <details class="group">
+                <summary class="cursor-pointer flex items-center justify-between gap-4 text-left [&::-webkit-details-marker]:hidden">
                     <h3 class="text-xl font-semibold text-primary-dark">{{ command.description|default:'(Sin descripción)' }}</h3>
-                    <p class="text-sm text-gray-500">Creado por {{ command.owner.email }} • {{ command.created_at|date:'d/m/Y H:i' }}</p>
-                </div>
-                <div class="flex items-start gap-3">
-                    <div class="text-sm text-gray-500 whitespace-nowrap">
-                        <i class="fas fa-clock mr-1"></i>{{ command.updated_at|timesince }} atrás
-                    </div>
-                    <div class="relative" data-command-menu>
-                        <button type="button" class="p-2 rounded-full hover:bg-gray-100 text-gray-500 hover:text-gray-700 transition" aria-haspopup="true" aria-expanded="false" data-command-menu-trigger>
-                            <span class="sr-only">Abrir acciones</span>
-                            <i class="fas fa-ellipsis-h"></i>
-                        </button>
-                        <div class="hidden absolute right-0 mt-2 w-40 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none z-10" role="menu" data-command-menu-items>
-                            <a href="{% url 'linux_commands:update' command.pk %}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" role="menuitem">
-                                <i class="fas fa-edit mr-2"></i>Editar
-                            </a>
-                            <form method="post" action="{% url 'linux_commands:delete' command.pk %}" data-command-delete-form>
-                                {% csrf_token %}
-                                <button type="submit" class="w-full text-left px-4 py-2 text-sm text-danger hover:bg-red-50 flex items-center gap-2" role="menuitem" data-confirm="¿Eliminar este comando?">
-                                    <i class="fas fa-trash-alt"></i>Eliminar
+                    <span class="flex items-center gap-2 text-sm text-primary-dark">
+                        <span class="group-open:hidden">Ver detalles</span>
+                        <span class="hidden group-open:inline">Ocultar detalles</span>
+                        <i class="fas fa-chevron-down transition-transform duration-200 group-open:rotate-180"></i>
+                    </span>
+                </summary>
+                <div class="mt-4 flex flex-col gap-4">
+                    <div class="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                        <p class="text-sm text-gray-500">Creado por {{ command.owner.email }} • {{ command.created_at|date:'d/m/Y H:i' }}</p>
+                        <div class="flex items-start gap-3">
+                            <div class="text-sm text-gray-500 whitespace-nowrap">
+                                <i class="fas fa-clock mr-1"></i>{{ command.updated_at|timesince }} atrás
+                            </div>
+                            <div class="relative" data-command-menu>
+                                <button type="button" class="p-2 rounded-full hover:bg-gray-100 text-gray-500 hover:text-gray-700 transition" aria-haspopup="true" aria-expanded="false" data-command-menu-trigger>
+                                    <span class="sr-only">Abrir acciones</span>
+                                    <i class="fas fa-ellipsis-h"></i>
                                 </button>
-                            </form>
+                                <div class="hidden absolute right-0 mt-2 w-40 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none z-10" role="menu" data-command-menu-items>
+                                    <a href="{% url 'linux_commands:update' command.pk %}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" role="menuitem">
+                                        <i class="fas fa-edit mr-2"></i>Editar
+                                    </a>
+                                    <form method="post" action="{% url 'linux_commands:delete' command.pk %}" data-command-delete-form>
+                                        {% csrf_token %}
+                                        <button type="submit" class="w-full text-left px-4 py-2 text-sm text-danger hover:bg-red-50 flex items-center gap-2" role="menuitem" data-confirm="¿Eliminar este comando?">
+                                            <i class="fas fa-trash-alt"></i>Eliminar
+                                        </button>
+                                    </form>
+                                </div>
+                            </div>
                         </div>
                     </div>
+
+                    <pre class="bg-gray-900 text-green-200 rounded-md p-4 text-sm overflow-x-auto"><code>{{ command.command }}</code></pre>
+
+                    {% if command.tags.all %}
+                    <div class="flex flex-wrap gap-2">
+                        {% for tag in command.tags.all %}
+                        <span class="px-3 py-1 bg-primary-light text-primary-dark rounded-full text-xs uppercase tracking-wide">#{{ tag.name }}</span>
+                        {% endfor %}
+                    </div>
+                    {% endif %}
+
+                    {% if command.flags.all %}
+                    <div>
+                        <h4 class="text-sm font-semibold text-gray-700 uppercase mb-2">Banderas</h4>
+                        <ul class="space-y-2">
+                            {% for flag in command.flags.all %}
+                            <li class="bg-gray-100 border border-gray-200 rounded-md p-3">
+                                <span class="font-mono font-semibold text-primary-dark">{{ flag.flag }}</span>
+                                <p class="text-sm text-gray-600">{{ flag.explanation }}</p>
+                            </li>
+                            {% endfor %}
+                        </ul>
+                    </div>
+                    {% endif %}
                 </div>
-            </div>
-            <pre class="bg-gray-900 text-green-200 rounded-md p-4 text-sm overflow-x-auto"><code>{{ command.command }}</code></pre>
-
-            {% if command.tags.all %}
-            <div class="flex flex-wrap gap-2">
-                {% for tag in command.tags.all %}
-                <span class="px-3 py-1 bg-primary-light text-primary-dark rounded-full text-xs uppercase tracking-wide">#{{ tag.name }}</span>
-                {% endfor %}
-            </div>
-            {% endif %}
-
-            {% if command.flags.all %}
-            <div>
-                <h4 class="text-sm font-semibold text-gray-700 uppercase mb-2">Banderas</h4>
-                <ul class="space-y-2">
-                    {% for flag in command.flags.all %}
-                    <li class="bg-gray-100 border border-gray-200 rounded-md p-3">
-                        <span class="font-mono font-semibold text-primary-dark">{{ flag.flag }}</span>
-                        <p class="text-sm text-gray-600">{{ flag.explanation }}</p>
-                    </li>
-                    {% endfor %}
-                </ul>
-            </div>
-            {% endif %}
+            </details>
         </div>
         {% endfor %}
     </div>


### PR DESCRIPTION
## Summary
- display the Linux command list with a single card per row
- wrap command metadata, command text, tags, and flags in a collapsible section so only the description is visible by default

## Testing
- python manage.py test linux_commands

------
https://chatgpt.com/codex/tasks/task_e_68df37f0d13c83309dc68afb0bf05fa3